### PR TITLE
Added N26 Bank Spain

### DIFF
--- a/es/n26/default.json
+++ b/es/n26/default.json
@@ -3,7 +3,7 @@
     "default_account": 1,
     "delimiter": "comma",
     "headers": true,
-    "ignore_duplicate_lines": true,
+    "ignore_duplicate_lines": false,
     "ignore_duplicate_transactions": true,
     "rules": true,
     "skip_form": false,


### PR DESCRIPTION
Hello James, adding a new bank for Spain. Thanks for your tool.

Changes in this pull request:

1. Created N26 Bank Spain. 

Parameter "ignore_duplicate_lines" set as FALSE, to avoid exclusion of identical transactions even in different dates (i.e.: money extractions of same amount)
Parameter "delimiter" set as "comma". Can easily be changed to "semicolon", depending on the region.


@JC5

